### PR TITLE
fix: bug when decoding 1-byte length clarity values at the end of an argument list

### DIFF
--- a/src/clarity_value/mod.rs
+++ b/src/clarity_value/mod.rs
@@ -68,7 +68,7 @@ pub fn decode_clarity_value_array(mut cx: FunctionContext) -> JsResult<JsArray> 
         let mut byte_cursor = std::io::Cursor::new(val_slice);
         let val_len = val_slice.len() as u64;
         let mut i: u32 = 0;
-        while byte_cursor.position() < val_len - 1 {
+        while byte_cursor.position() < val_len {
             let cursor_pos = byte_cursor.position();
             let clarity_value = ClarityValue::deserialize(&mut byte_cursor, deep)
                 .or_else(|e| cx.throw_error(format!("Error deserializing Clarity value: {}", e)))?;

--- a/tests/clarity-value-list-decode.test.ts
+++ b/tests/clarity-value-list-decode.test.ts
@@ -22,3 +22,22 @@ test('decode value array 3', () => {
   ]);
 });
 
+test('decode value array single byte last arg none', () => {
+  const decoded = decodeClarityValueList('0x00000004010000000000000000000000000098968005164fefdd611090e9a6968dfaa4418480e3be7cc6e905162bdbfd08952341678dd72607eedf89c24447506209');
+  expect(decoded).toEqual([
+    { "hex": "0x0100000000000000000000000000989680", "repr": "u10000000", "type_id": 1 },
+    { "hex": "0x05164fefdd611090e9a6968dfaa4418480e3be7cc6e9", "repr": "'SP17YZQB1228EK9MPHQXA8GC4G3HVWZ66X7VRPMAX", "type_id": 5 },
+    { "hex": "0x05162bdbfd08952341678dd72607eedf89c244475062", "repr": "'SPNXQZ88JMHM2SWDTWK0FVPZH7148HTGCAB3WGBP", "type_id": 5 },
+    { "hex": "0x09", "repr": "none", "type_id": 9 }
+  ]);
+});
+
+test('decode value array single byte last arg bool', () => {
+  const decoded = decodeClarityValueList('0x00000004010000000000000000000000000098968005164fefdd611090e9a6968dfaa4418480e3be7cc6e905162bdbfd08952341678dd72607eedf89c24447506204');
+  expect(decoded).toEqual([
+    { "hex": "0x0100000000000000000000000000989680", "repr": "u10000000", "type_id": 1 },
+    { "hex": "0x05164fefdd611090e9a6968dfaa4418480e3be7cc6e9", "repr": "'SP17YZQB1228EK9MPHQXA8GC4G3HVWZ66X7VRPMAX", "type_id": 5 },
+    { "hex": "0x05162bdbfd08952341678dd72607eedf89c244475062", "repr": "'SPNXQZ88JMHM2SWDTWK0FVPZH7148HTGCAB3WGBP", "type_id": 5 },
+    { "hex": "0x04", "repr": "false", "type_id": 4 }
+  ]);
+});


### PR DESCRIPTION
Related to https://github.com/hirosystems/stacks-blockchain-api/issues/1188

Fixes off-by-one bug while decoding through a serialized Clarity value array. If the last value was a single byte, it was skipped.

A payload with a single-byte value (like `optional-none`) at the end, like `0x00000004010000000000000000000000000098968005164fefdd611090e9a6968dfaa4418480e3be7cc6e905162bdbfd08952341678dd72607eedf89c24447506209`, would result in `decodeClarityValueList(...)` returning an array with the last value being null/undefined.

See https://stacks-node-api.stacks.co/extended/v1/tx/0xdb3f5705c39de4b34c1db21da7a380dae30e6f06c9ce085d47ea3be15db6ef90

Bugged:
```json
"function_args": [
  {
    "hex": "0x0100000000000000000000000000989680",
    "repr": "u10000000",
    "name": "amount",
    "type": "uint"
  },
  {
    "hex": "0x05164fefdd611090e9a6968dfaa4418480e3be7cc6e9",
    "repr": "'SP17YZQB1228EK9MPHQXA8GC4G3HVWZ66X7VRPMAX",
    "name": "from",
    "type": "principal"
  },
  {
    "hex": "0x05162bdbfd08952341678dd72607eedf89c244475062",
    "repr": "'SPNXQZ88JMHM2SWDTWK0FVPZH7148HTGCAB3WGBP",
    "name": "to",
    "type": "principal"
  },
  null
]
```

Fixed:
```json
"function_args": [
  {
    "hex": "0x0100000000000000000000000000989680",
    "repr": "u10000000",
    "name": "amount",
    "type": "uint"
  },
  {
    "hex": "0x05164fefdd611090e9a6968dfaa4418480e3be7cc6e9",
    "repr": "'SP17YZQB1228EK9MPHQXA8GC4G3HVWZ66X7VRPMAX",
    "name": "from",
    "type": "principal"
  },
  {
    "hex": "0x05162bdbfd08952341678dd72607eedf89c244475062",
    "repr": "'SPNXQZ88JMHM2SWDTWK0FVPZH7148HTGCAB3WGBP",
    "name": "to",
    "type": "principal"
  },
  {
    "hex": "0x04",
    "repr": "false",
    "name": "memo",
    "type_id": 4
  }
]
```