### PR TITLE
fix: support new staking/pox post conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
 dependencies = [
  "lazy_static",
  "regex",
@@ -203,6 +203,7 @@ dependencies = [
  "serde_json",
  "slog",
  "stacks-common",
+ "variant_count",
 ]
 
 [[package]]
@@ -927,7 +928,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
 dependencies = [
  "clarity",
  "serde",
@@ -1150,7 +1151,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
 dependencies = [
  "clarity",
  "slog",
@@ -1553,12 +1554,18 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
+dependencies = [
+ "clarity-types",
+ "serde",
+ "stacks-common",
+ "variant_count",
+]
 
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -1579,7 +1586,6 @@ dependencies = [
  "sha3",
  "slog",
  "slog-term",
- "stacks-codec",
  "thiserror",
  "toml",
  "winapi 0.3.9",
@@ -1608,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=ca46d23f6fd97ef1a16d23a9966d20c94c19765d#ca46d23f6fd97ef1a16d23a9966d20c94c19765d"
+source = "git+https://github.com/stacks-network/stacks-core?rev=7d5b25b9d227c52aa34afb8b712a1cd351c08d88#7d5b25b9d227c52aa34afb8b712a1cd351c08d88"
 dependencies = [
  "clarity",
  "ed25519-dalek",
@@ -1631,6 +1637,7 @@ dependencies = [
  "sha2 0.10.2",
  "siphasher",
  "slog",
+ "stacks-codec",
  "stacks-common",
  "time",
  "toml",
@@ -1817,6 +1824,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "variant_count"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1935e10c6f04d22688d07c0790f2fc0e1b1c5c2c55bc0cc87ed67656e587dd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ crate-type = ["lib", "cdylib"]
 #
 # IMPORTANT: keep the rev pin in sync across all three deps. The update script
 # enforces this.
-stacks-codec = { git = "https://github.com/stacks-network/stacks-core", rev = "ca46d23f6fd97ef1a16d23a9966d20c94c19765d" }
-stacks_common = { package = "stacks-common", git = "https://github.com/stacks-network/stacks-core", rev = "ca46d23f6fd97ef1a16d23a9966d20c94c19765d", default-features = false }
-clarity = { git = "https://github.com/stacks-network/stacks-core", rev = "ca46d23f6fd97ef1a16d23a9966d20c94c19765d", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core", rev = "ca46d23f6fd97ef1a16d23a9966d20c94c19765d" }
+stacks-codec = { git = "https://github.com/stacks-network/stacks-core", rev = "7d5b25b9d227c52aa34afb8b712a1cd351c08d88" }
+stacks_common = { package = "stacks-common", git = "https://github.com/stacks-network/stacks-core", rev = "7d5b25b9d227c52aa34afb8b712a1cd351c08d88", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core", rev = "7d5b25b9d227c52aa34afb8b712a1cd351c08d88", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core", rev = "7d5b25b9d227c52aa34afb8b712a1cd351c08d88" }
 
 # === This crate's own dependencies ===
 git-version = "0.3.5"

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,12 @@ export * from './loader.js';
 export const StacksNativeEncodingBindings = bindings;
 export default StacksNativeEncodingBindings;
 
-export type TxPostCondition = PostConditionStx | PostConditionFungible | PostConditionNonfungible;
+export type TxPostCondition =
+  | PostConditionStx
+  | PostConditionFungible
+  | PostConditionNonfungible
+  | PostConditionStaking
+  | PostConditionPox;
 
 export interface DecodedPostConditionsResult {
   post_condition_mode: PostConditionModeID;
@@ -37,6 +42,8 @@ export enum PostConditionAssetInfoID {
   STX = 0,
   FungibleAsset = 1,
   NonfungibleAsset = 2,
+  Staking = 3,
+  Pox = 4,
 }
 
 export interface PostConditionStx {
@@ -65,10 +72,47 @@ export interface PostConditionNonfungible {
   condition_name: PostConditionNonFungibleConditionName;
 }
 
+/**
+ * Constrains how much STX a principal may stake (lock for PoX) during the
+ * transaction. Only valid in Stacks epoch 4.0 and later.
+ */
+export interface PostConditionStaking {
+  asset_info_id: PostConditionAssetInfoID.Staking;
+  principal: PostConditionPrincipal;
+  condition_code: PostConditionFungibleConditionCodeID;
+  condition_name: PostConditionFungibleConditionCodeName;
+  amount: string;
+}
+
+/**
+ * Constrains whether a principal may perform a position-altering PoX
+ * operation (`unstake`, `unstake-sbtc`, `update-bond-registration`,
+ * `announce-l1-early-exit`) during the transaction. Only valid in Stacks
+ * epoch 4.0 and later.
+ */
+export interface PostConditionPox {
+  asset_info_id: PostConditionAssetInfoID.Pox;
+  principal: PostConditionPrincipal;
+  condition_code: PostConditionPoxConditionCodeID;
+  condition_name: PostConditionPoxConditionCodeName;
+}
+
 export interface PostConditionAssetInfo {
   contract_address: string;
   contract_name: string;
   asset_name: string;
+}
+
+export enum PostConditionPoxConditionCodeID {
+  NotPerformed = 0x30,
+  MaybePerformed = 0x31,
+  Performed = 0x32,
+}
+
+export enum PostConditionPoxConditionCodeName {
+  NotPerformed = 'not_performed',
+  MaybePerformed = 'maybe_performed',
+  Performed = 'performed',
 }
 
 export enum PostConditionNonfungibleConditionCodeID {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stacks/codec",
-  "version": "2.0.0-pox5.3",
+  "version": "2.0.0-pox5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stacks/codec",
-      "version": "2.0.0-pox5.3",
+      "version": "2.0.0-pox5.4",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/codec",
-  "version": "2.0.0-pox5.3",
+  "version": "2.0.0-pox5.4",
   "author": "Stacks Labs",
   "license": "GPL-3.0",
   "description": "Encoding & decoding functions for the Stacks blockchain exposed as a fast native Node.js addon",

--- a/src/upstream/post_condition/mod.rs
+++ b/src/upstream/post_condition/mod.rs
@@ -11,7 +11,7 @@ use std::{convert::TryInto, io::Cursor};
 
 pub use blockstack_lib::chainstate::stacks::{
     AssetInfo, AssetInfoID, FungibleConditionCode, NonfungibleConditionCode,
-    PostConditionPrincipal, PostConditionPrincipalID, TransactionPostCondition,
+    PostConditionPrincipal, PostConditionPrincipalID, PoxConditionCode, TransactionPostCondition,
 };
 use neon::prelude::*;
 use stacks_codec::StacksMessageCodec;

--- a/src/upstream/post_condition/neon_encoder.rs
+++ b/src/upstream/post_condition/neon_encoder.rs
@@ -12,7 +12,7 @@ use crate::util::neon::{Encode, NeonJsSerialize};
 
 use super::{
     AssetInfo, AssetInfoID, FungibleConditionCode, NonfungibleConditionCode,
-    PostConditionPrincipal, PostConditionPrincipalID, TransactionPostCondition,
+    PostConditionPrincipal, PostConditionPrincipalID, PoxConditionCode, TransactionPostCondition,
 };
 
 impl NeonJsSerialize for Encode<'_, TransactionPostCondition> {
@@ -82,6 +82,29 @@ impl NeonJsSerialize for Encode<'_, TransactionPostCondition> {
                 obj.set(cx, "asset_value", asset_value_obj)?;
 
                 Encode(nonfungible_condition).neon_js_serialize(cx, obj, &())?;
+            }
+            TransactionPostCondition::Staking(principal, fungible_condition, amount) => {
+                let asset_info_id = cx.number(AssetInfoID::Staking as u8);
+                obj.set(cx, "asset_info_id", asset_info_id)?;
+
+                let principal_obj = cx.empty_object();
+                Encode(principal).neon_js_serialize(cx, &principal_obj, &())?;
+                obj.set(cx, "principal", principal_obj)?;
+
+                Encode(fungible_condition).neon_js_serialize(cx, obj, &())?;
+
+                let amount_str = cx.string(amount.to_string());
+                obj.set(cx, "amount", amount_str)?;
+            }
+            TransactionPostCondition::Pox(principal, pox_condition) => {
+                let asset_info_id = cx.number(AssetInfoID::Pox as u8);
+                obj.set(cx, "asset_info_id", asset_info_id)?;
+
+                let principal_obj = cx.empty_object();
+                Encode(principal).neon_js_serialize(cx, &principal_obj, &())?;
+                obj.set(cx, "principal", principal_obj)?;
+
+                Encode(pox_condition).neon_js_serialize(cx, obj, &())?;
             }
         }
         Ok(())
@@ -153,6 +176,26 @@ impl NeonJsSerialize for Encode<'_, NonfungibleConditionCode> {
             NonfungibleConditionCode::Sent => "sent",
             NonfungibleConditionCode::NotSent => "not_sent",
             NonfungibleConditionCode::MaybeSent => "maybe_sent",
+        };
+        let condition_code = cx.number(*self.0 as u8);
+        obj.set(cx, "condition_code", condition_code)?;
+        let condition_name_str = cx.string(condition_name);
+        obj.set(cx, "condition_name", condition_name_str)?;
+        Ok(())
+    }
+}
+
+impl NeonJsSerialize for Encode<'_, PoxConditionCode> {
+    fn neon_js_serialize(
+        &self,
+        cx: &mut FunctionContext,
+        obj: &Handle<JsObject>,
+        _extra_ctx: &(),
+    ) -> NeonResult<()> {
+        let condition_name = match self.0 {
+            PoxConditionCode::NotPerformed => "not_performed",
+            PoxConditionCode::MaybePerformed => "maybe_performed",
+            PoxConditionCode::Performed => "performed",
         };
         let condition_code = cx.number(*self.0 as u8);
         obj.set(cx, "condition_code", condition_code)?;


### PR DESCRIPTION
## What

Bumps the upstream `stacks-network/stacks-core` pin to [`7d5b25b`](https://github.com/stacks-network/stacks-core/commit/7d5b25b9d227c52aa34afb8b712a1cd351c08d88) and adds decoding support for the two new epoch-4.0 transaction post-condition variants it introduces:

| Variant | Wire `asset_info_id` | Shape |
|---|---|---|
| `Staking` | `3` | constrains how much STX a principal may stake (lock for PoX) — same shape as the `STX` post-condition (principal + `FungibleConditionCode` + amount) |
| `Pox` | `4` | gates position-altering PoX ops (`unstake`, `unstake-sbtc`, `update-bond-registration`, `announce-l1-early-exit`) — presence-based, like NFT conditions (principal + `PoxConditionCode`) |

## Why

The new pin adds `TransactionPostCondition::Staking` and `::Pox`, which made the existing post-condition encoder's `match` non-exhaustive and broke the build. These cover the new PoX-5 staking/bond post-conditions.

## Changes

- **`Cargo.toml` / `Cargo.lock`** — re-pinned the four upstream crates (`stacks-codec`, `stacks-common`, `clarity`, `stackslib`) to `7d5b25b` via `scripts/update-stacks-core.sh`.
- **`src/upstream/post_condition/mod.rs`** — re-export `PoxConditionCode` from `blockstack_lib`.
- **`src/upstream/post_condition/neon_encoder.rs`** — two new match arms (`Staking` mirrors `STX`; `Pox` emits principal + condition) and a `NeonJsSerialize` impl for `PoxConditionCode` (`0x30/0x31/0x32` → `not_performed` / `maybe_performed` / `performed`).
- **`index.ts`** — `PostConditionAssetInfoID` gained `Staking = 3` / `Pox = 4`; added `PostConditionStaking` + `PostConditionPox` interfaces, the `PostConditionPoxConditionCodeID` / `…Name` enums, and both to the `TxPostCondition` union.

## Notes for reviewers

- Deserialization itself goes through upstream's canonical `consensus_deserialize`, so only the JS-facing encoding needed changes here.
- Verification: `cargo fmt --check`, `cargo clippy` (0 warnings), 65 Rust unit tests, TS build, native build against the new pin, and 42 Jest tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)